### PR TITLE
Fix Playback tracker `IndexOutOfBoundsException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+### Fixed
+
+- `IndexOutOfBoundsException` when jumping from an ad break to another ad break with less ads then the previous active ad index
 
 ## [0.1.0-alpha.6] - 2025-07-03
 

--- a/mediatailor/src/main/java/com/bitmovin/player/integration/mediatailor/AdPlaybackTracker.kt
+++ b/mediatailor/src/main/java/com/bitmovin/player/integration/mediatailor/AdPlaybackTracker.kt
@@ -79,6 +79,7 @@ internal class DefaultAdPlaybackTracker(
             player.currentTime >= adBreaks[currentAdBreakIndex].endTime
         ) {
             currentAdBreakIndex++
+            currentAdIndex = 0
         }
 
         val adBreak = adBreaks[currentAdBreakIndex]
@@ -98,7 +99,6 @@ internal class DefaultAdPlaybackTracker(
 
         if (player.currentTime !in adBreak.startToEndTime) {
             _playingAdBreak.update { null }
-            currentAdIndex = 0
             return
         }
 


### PR DESCRIPTION
### Problem
The `currentAdIndex` was not always updated when `currentAdBreakIndex` changed, this caused an `IndexOutOfBoundsException` to be thrown.

### Changes
- Always reset the `currentAdIndex` when changing `currentAdBreakIndex`