### PR TITLE
Emit missing ad related events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `MediaTailorSessionManager` not emitting all ad related events when seeking or time shifting from an active ad break to another ad break
+
 ## [0.1.0-alpha.6] - 2025-07-03
 
 ### Added

--- a/mediatailor/src/main/java/com/bitmovin/player/integration/mediatailor/AdPlaybackEventEmitter.kt
+++ b/mediatailor/src/main/java/com/bitmovin/player/integration/mediatailor/AdPlaybackEventEmitter.kt
@@ -25,6 +25,7 @@ internal class DefaultAdPlaybackEventEmitter(
         }
         scope.launch {
             adPlaybackTracker.playingAdBreak.collect { playingAdBreak ->
+                val previousPlayingAdBreak = previousPlayingAdBreak
                 when {
                     previousPlayingAdBreak == null && playingAdBreak != null -> {
                         eventEmitter.emit(MediaTailorEvent.AdBreakStarted(playingAdBreak.adBreak))
@@ -37,9 +38,9 @@ internal class DefaultAdPlaybackEventEmitter(
                     }
 
                     previousPlayingAdBreak != null && playingAdBreak != null &&
-                        previousPlayingAdBreak!!.adBreak.id != playingAdBreak.adBreak.id -> {
-                        eventEmitter.emit(MediaTailorEvent.AdFinished(previousPlayingAdBreak!!.ad))
-                        eventEmitter.emit(MediaTailorEvent.AdBreakFinished(previousPlayingAdBreak!!.adBreak))
+                        previousPlayingAdBreak.adBreak.id != playingAdBreak.adBreak.id -> {
+                        eventEmitter.emit(MediaTailorEvent.AdFinished(previousPlayingAdBreak.ad))
+                        eventEmitter.emit(MediaTailorEvent.AdBreakFinished(previousPlayingAdBreak.adBreak))
                         eventEmitter.emit(MediaTailorEvent.AdBreakStarted(playingAdBreak.adBreak))
                         eventEmitter.emit(
                             MediaTailorEvent.AdStarted(
@@ -51,7 +52,7 @@ internal class DefaultAdPlaybackEventEmitter(
 
                     playingAdBreak != null && previousPlayingAdBreak?.ad?.id != playingAdBreak.ad.id -> {
                         if (previousPlayingAdBreak?.ad != null) {
-                            eventEmitter.emit(MediaTailorEvent.AdFinished(previousPlayingAdBreak!!.ad))
+                            eventEmitter.emit(MediaTailorEvent.AdFinished(previousPlayingAdBreak.ad))
                         }
                         eventEmitter.emit(
                             MediaTailorEvent.AdStarted(
@@ -62,12 +63,12 @@ internal class DefaultAdPlaybackEventEmitter(
                     }
 
                     previousPlayingAdBreak != null && playingAdBreak == null -> {
-                        eventEmitter.emit(MediaTailorEvent.AdFinished(previousPlayingAdBreak!!.ad))
-                        eventEmitter.emit(MediaTailorEvent.AdBreakFinished(previousPlayingAdBreak!!.adBreak))
+                        eventEmitter.emit(MediaTailorEvent.AdFinished(previousPlayingAdBreak.ad))
+                        eventEmitter.emit(MediaTailorEvent.AdBreakFinished(previousPlayingAdBreak.adBreak))
                     }
                 }
 
-                previousPlayingAdBreak = playingAdBreak
+                this@DefaultAdPlaybackEventEmitter.previousPlayingAdBreak = playingAdBreak
             }
         }
     }

--- a/mediatailor/src/main/java/com/bitmovin/player/integration/mediatailor/AdPlaybackEventEmitter.kt
+++ b/mediatailor/src/main/java/com/bitmovin/player/integration/mediatailor/AdPlaybackEventEmitter.kt
@@ -36,6 +36,19 @@ internal class DefaultAdPlaybackEventEmitter(
                         )
                     }
 
+                    previousPlayingAdBreak != null && playingAdBreak != null
+                            && previousPlayingAdBreak!!.adBreak.id != playingAdBreak.adBreak.id -> {
+                        eventEmitter.emit(MediaTailorEvent.AdFinished(previousPlayingAdBreak!!.ad))
+                        eventEmitter.emit(MediaTailorEvent.AdBreakFinished(previousPlayingAdBreak!!.adBreak))
+                        eventEmitter.emit(MediaTailorEvent.AdBreakStarted(playingAdBreak.adBreak))
+                        eventEmitter.emit(
+                            MediaTailorEvent.AdStarted(
+                                ad = playingAdBreak.ad,
+                                indexInQueue = playingAdBreak.adIndex,
+                            ),
+                        )
+                    }
+
                     playingAdBreak != null && previousPlayingAdBreak?.ad?.id != playingAdBreak.ad.id -> {
                         if (previousPlayingAdBreak?.ad != null) {
                             eventEmitter.emit(MediaTailorEvent.AdFinished(previousPlayingAdBreak!!.ad))

--- a/mediatailor/src/main/java/com/bitmovin/player/integration/mediatailor/AdPlaybackEventEmitter.kt
+++ b/mediatailor/src/main/java/com/bitmovin/player/integration/mediatailor/AdPlaybackEventEmitter.kt
@@ -36,8 +36,8 @@ internal class DefaultAdPlaybackEventEmitter(
                         )
                     }
 
-                    previousPlayingAdBreak != null && playingAdBreak != null
-                            && previousPlayingAdBreak!!.adBreak.id != playingAdBreak.adBreak.id -> {
+                    previousPlayingAdBreak != null && playingAdBreak != null &&
+                        previousPlayingAdBreak!!.adBreak.id != playingAdBreak.adBreak.id -> {
                         eventEmitter.emit(MediaTailorEvent.AdFinished(previousPlayingAdBreak!!.ad))
                         eventEmitter.emit(MediaTailorEvent.AdBreakFinished(previousPlayingAdBreak!!.adBreak))
                         eventEmitter.emit(MediaTailorEvent.AdBreakStarted(playingAdBreak.adBreak))

--- a/mediatailor/src/test/java/com/bitmovin/player/integration/mediatailor/AdPlaybackEventEmitterSpec.kt
+++ b/mediatailor/src/test/java/com/bitmovin/player/integration/mediatailor/AdPlaybackEventEmitterSpec.kt
@@ -155,6 +155,69 @@ class AdPlaybackEventEmitterSpec : DescribeSpec({
             }
         }
 
+        describe("when the ad break changes") {
+            beforeEach {
+                playingAdBreak.emit(
+                    PlayingAdBreak(
+                        adBreak = MediaTailorAdBreak(
+                            id = "adBreak2",
+                            ads = listOf(
+                                MediaTailorLinearAd(
+                                    id = "ad2",
+                                    scheduleTime = 0.0,
+                                    duration = 10.0,
+                                    formattedDuration = "10",
+                                    trackingEvents = emptyList(),
+                                ),
+                            ),
+                            scheduleTime = 0.0,
+                            duration = 10.0,
+                            formattedDuration = "10",
+                            adMarkerDuration = "10",
+                        ),
+                        adIndex = 0,
+                    ),
+                )
+            }
+
+            it("emits ad break finished event for the previous ad break") {
+                expectThat(testEventEmitter.emittedEvents).any {
+                    isA<MediaTailorEvent.AdBreakFinished>()
+                        .and {
+                            get { adBreak.id }.isEqualTo("adBreak1")
+                        }
+                }
+            }
+
+            it("emits ad finished event for the previous ad") {
+                expectThat(testEventEmitter.emittedEvents).any {
+                    isA<MediaTailorEvent.AdFinished>()
+                        .and {
+                            get { ad.id }.isEqualTo("ad1")
+                        }
+                }
+            }
+
+            it("emits ad break started event for the new ad break") {
+                expectThat(testEventEmitter.emittedEvents).any {
+                    isA<MediaTailorEvent.AdBreakStarted>()
+                        .and {
+                            get { adBreak.id }.isEqualTo("adBreak2")
+                        }
+                }
+            }
+
+            it("emits ad started event for the new ad") {
+                expectThat(testEventEmitter.emittedEvents).any {
+                    isA<MediaTailorEvent.AdStarted>()
+                        .and {
+                            get { ad.id }.isEqualTo("ad2")
+                            get { indexInQueue }.isEqualTo(0)
+                        }
+                }
+            }
+        }
+
         describe("when the current ad changes") {
             beforeEach {
                 playingAdBreak.emit(


### PR DESCRIPTION
### Problem
When seeking / time shifting from an active ad break to another ad break, the ad related events were not emitted (AdFinished, AdBreakFinished, AdBreakStarted, AdStarted).

### Changes
- Emit the missing ad related events when the active ad break is changed